### PR TITLE
Feature/docs 0.7

### DIFF
--- a/docs/docs.fsx
+++ b/docs/docs.fsx
@@ -173,23 +173,6 @@ let generateStaticPages siteRoot force () =
 // --------------------------------------------------------------------------------------
 
 
-/// Install 'core-js' and 'requirejs' into temp & copy the JS files
-/// into the output folder (we may need to add more dependencies here)
-let copySharedScripts () =
-    CleanDir temp
-    // Npm.run temp "init" ["--yes"]
-    // Npm.install
-    //     temp
-    //     [
-    //         "core-js@^2.4.1"
-    //         "fable-compiler@^0.7.19"
-    //         "fable-core@^0.7.15"
-    //         "fable-import-pixi@^0.0.10"
-    //         "babel-plugin-transform-runtime@^6.15.0"
-    //         "pixi.js@3.0.11"
-    //     ]
-
-
 /// Extract string (from HTML page) enclosed between
 /// <!-- [tag] --> and <!-- [/tag] -->
 let extractMarkedPagePart tag (page:string) =
@@ -361,7 +344,6 @@ Target "CleanDocs" (fun _ ->
 )
 
 Target "GenerateDocs" (fun _ ->
-    copySharedScripts ()
     prepareDependencies ()
     generateStaticPages publishSite true ()
     generateSamplePages publishSite true ()
@@ -370,7 +352,6 @@ Target "GenerateDocs" (fun _ ->
 Target "BrowseDocs" (fun _ ->
     // Update static pages & sample pages (but don't recompile JS)
     let root = "http://localhost:8911"
-    copySharedScripts ()
     prepareDependencies ()
     generateStaticPages root true ()
     generateSamplePages root false ()

--- a/docs/docs.fsx
+++ b/docs/docs.fsx
@@ -53,7 +53,7 @@ let samples =
       "samples/pixi/movieclip", "pixi"
       "samples/pixi/particle-container", "pixi"
       "samples/pixi/render-texture", "pixi"
-      "samples/pixi/masking", "pixi" 
+      "samples/pixi/masking", "pixi"
     ]
 
 
@@ -177,7 +177,17 @@ let generateStaticPages siteRoot force () =
 /// into the output folder (we may need to add more dependencies here)
 let copySharedScripts () =
     CleanDir temp
-    Npm.run temp "init" ["--yes"]
+    // Npm.run temp "init" ["--yes"]
+    // Npm.install
+    //     temp
+    //     [
+    //         "core-js@^2.4.1"
+    //         "fable-compiler@^0.7.19"
+    //         "fable-core@^0.7.15"
+    //         "fable-import-pixi@^0.0.10"
+    //         "babel-plugin-transform-runtime@^6.15.0"
+    //         "pixi.js@3.0.11"
+    //     ]
 
 
 /// Extract string (from HTML page) enclosed between
@@ -187,21 +197,15 @@ let extractMarkedPagePart tag (page:string) =
     let mtch = Regex.Match(page, pattern, RegexOptions.Singleline)
     if mtch.Success then mtch.Groups.[1].Value else ""
 
+let prepareDependencies () =
+    Npm.run samplesRoot "i" []
 
 /// Compile sample using Fable & copy static and JS files to `samples/<name>`
-let compileSample copyOutput name path outerDir =
+let compileSample copyOutput name (path: string) outerDir =
     // Compile and copy JS files
-    CleanDir temp
     System.Environment.CurrentDirectory <- fableRoot
 
-    Npm.install path []
     Npm.run path "run" ["build"]
-    // NpmHelper.Npm (fun p ->
-    //     { p with
-    //         Command = (NpmHelper.Run "build")
-    //         WorkingDirectory = path
-    //     })
-//    NpmHelper.run (fun p -> ()) // fableRoot "fable" [path; "-o"; "../../../temp"; "--symbols"; "TUTORIAL"]
     ensureDirectory (output </> "samples" </> outerDir </> name)
 
     if copyOutput then
@@ -265,10 +269,7 @@ let generateSamplePage siteRoot dir name (path: string) outerDir =
     let externalScript =
         if not (attrs.ContainsKey("external-script")) then "" else
         Regex.Match(attrs.["external-script"], "<code>(.*)</code>").Groups.[1].Value
-    
 
-    Console.WriteLine(externalScript)
-    
 
     // Get `title` and `tagline` from the attrs and generate sample page
     let html =
@@ -361,6 +362,7 @@ Target "CleanDocs" (fun _ ->
 
 Target "GenerateDocs" (fun _ ->
     copySharedScripts ()
+    prepareDependencies ()
     generateStaticPages publishSite true ()
     generateSamplePages publishSite true ()
 )
@@ -369,6 +371,7 @@ Target "BrowseDocs" (fun _ ->
     // Update static pages & sample pages (but don't recompile JS)
     let root = "http://localhost:8911"
     copySharedScripts ()
+    prepareDependencies ()
     generateStaticPages root true ()
     generateSamplePages root false ()
 

--- a/docs/templates/sample.html
+++ b/docs/templates/sample.html
@@ -3,8 +3,6 @@
   <title>{{ model.Title }} - F# |> BABEL</title>
   {{ model.Head }}
   <meta name="description" content="{{ model.Tagline }}">
-  <script src="../../scripts/core.min.js"></script>
-  <script src="../../scripts/require.js"></script>
 {% endblock %}
 
 {% block content %}
@@ -28,18 +26,13 @@
     <div class="col-md-1 col-lg-2"></div>
   </div>
 
+  <script src={{ model.ExternalScript }}></script>
+
   <div class="row">
     <div class="col-sm-12">
       <div class="app-container" style="{{ model.AppStyle }}">
         {{ model.Application }}
       </div>
-      <script>
-        requirejs.config({
-          baseUrl: 'public',
-          paths: { 'fable-core': '../../../scripts/fable-core.min', {{ model.RequirePaths }} }
-        });
-        requirejs(["{{ model.Name }}"]);
-      </script>
     </div>
   </div>
 

--- a/samples/package.json
+++ b/samples/package.json
@@ -11,10 +11,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "core-js": "^2.4.1",
-    "fable-compiler": "^0.5.11",
-    "fable-core": "^0.6.10",
-    "fable-import-pixi": "0.0.7",
-    "pixi.js": "^3.0.11"
+    "finalhandler": "^0.5.0",
+    "open": "0.0.5",
+    "pixi.js": "^3.0.11",
+    "requirejs": "^2.2.0",
+    "serve-static": "^1.11.1"
   }
 }

--- a/samples/package.json
+++ b/samples/package.json
@@ -15,6 +15,11 @@
     "open": "0.0.5",
     "pixi.js": "^3.0.11",
     "requirejs": "^2.2.0",
-    "serve-static": "^1.11.1"
+    "serve-static": "^1.11.1",
+    "core-js": "^2.4.1",
+    "fable-compiler": "^0.7.19",
+    "fable-core": "^0.7.15",
+    "fable-import-pixi": "0.0.10",
+    "babel-plugin-transform-runtime": "^6.15.0"
   }
 }

--- a/samples/package.json
+++ b/samples/package.json
@@ -15,10 +15,6 @@
     "fable-compiler": "^0.5.11",
     "fable-core": "^0.6.10",
     "fable-import-pixi": "0.0.7",
-    "finalhandler": "^0.5.0",
-    "open": "0.0.5",
-    "pixi.js": "^3.0.11",
-    "requirejs": "^2.2.0",
-    "serve-static": "^1.11.1"
+    "pixi.js": "^3.0.11"
   }
 }

--- a/samples/pixi/basic/basic.fsx
+++ b/samples/pixi/basic/basic.fsx
@@ -2,18 +2,20 @@
  - title: Basic sample
  - tagline: Basic sample implemented with fable-pixi
  - app-style: width:800px; margin:20px auto 50px auto;
- - require-paths: `'PIXI':'https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min'`
+ - external-script: `"https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min.js"`
  - intro: This is a port from [basic sample](http://pixijs.github.io/examples/#/basics/basic.js)
 *)
 
-#r "../../node_modules/fable-core/Fable.Core.dll"
-#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "./node_modules/fable-core/Fable.Core.dll"
+#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Import.PIXI
 open Fable.Import.Browser
+
+importAll "core-js"
 
 let options = [
   BackgroundColor (float 0x1099bb)

--- a/samples/pixi/basic/basic.fsx
+++ b/samples/pixi/basic/basic.fsx
@@ -6,8 +6,8 @@
  - intro: This is a port from [basic sample](http://pixijs.github.io/examples/#/basics/basic.js)
 *)
 
-#r "./node_modules/fable-core/Fable.Core.dll"
-#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "../../node_modules/fable-core/Fable.Core.dll"
+#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core

--- a/samples/pixi/basic/fableconfig.json
+++ b/samples/pixi/basic/fableconfig.json
@@ -1,6 +1,13 @@
 {
-    "module": "amd",
-    "sourceMaps": true,
     "projFile": "./basic.fsx",
-    "outDir": "public"
+    "sourceMaps": true,
+    "babelPlugins": ["transform-runtime"],
+    "rollup": {
+        "dest": "public/bundle.js",
+        // PIXI will be loaded directly from a script tag
+        "external": ["PIXI"],
+        "globals": {
+            "PIXI": "PIXI"
+        }
+    }
 }

--- a/samples/pixi/basic/index.html
+++ b/samples/pixi/basic/index.html
@@ -14,24 +14,11 @@
   </head>
   <body>
 
+    <script src="./node_modules/pixi.js/bin/pixi.min.js"></script>
     <!-- [body] -->
     <div id="game"></div>
+    <script src="./public/bundle.js"></script>
     <!-- [/body] -->
-    <script src="../../node_modules/core-js/client/core.min.js"></script>
-    <script src="../../node_modules/requirejs/require.js"></script>
 
-    <script>
-      requirejs.config({
-        // Set the baseUrl to the path of the compiled JS code
-        baseUrl: 'public',
-        paths: {
-          // Explicit path to core lib (relative to baseUrl, omit .js)
-          'fable-core': '../../../node_modules/fable-core/fable-core.min',
-          'PIXI': '../../../node_modules/pixi.js/bin/pixi.min'
-        }
-      });
-      // Load the entry file of the app (use array, omit .js)
-      requirejs(["basic"]);
-    </script>
   </body>
 </html>

--- a/samples/pixi/basic/package.json
+++ b/samples/pixi/basic/package.json
@@ -5,17 +5,9 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-    "build": "node ./node_modules/fable-compiler",
+    "build": "node ../../node_modules/fable-compiler",
     "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT",
-  "dependencies": {
-    "core-js": "^2.4.1",
-    "fable-compiler": "^0.7.19",
-    "fable-core": "^0.7.15",
-    "fable-import-pixi": "0.0.10",
-    "pixi.js": "^3.0.11",
-    "babel-plugin-transform-runtime": "^6.15.0"
-  }
+  "license": "MIT"
 }

--- a/samples/pixi/basic/package.json
+++ b/samples/pixi/basic/package.json
@@ -5,9 +5,17 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-      "build": "node ../../node_modules/fable-compiler",
-      "start": "node ../../server"
+    "build": "node ./node_modules/fable-compiler",
+    "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "core-js": "^2.4.1",
+    "fable-compiler": "^0.7.19",
+    "fable-core": "^0.7.15",
+    "fable-import-pixi": "0.0.10",
+    "pixi.js": "^3.0.11",
+    "babel-plugin-transform-runtime": "^6.15.0"
+  }
 }

--- a/samples/pixi/blur-filter/blur-filter.fsx
+++ b/samples/pixi/blur-filter/blur-filter.fsx
@@ -6,8 +6,8 @@
  - intro: This is a port from [blur filter sample](http://pixijs.github.io/examples/#/filters/blur-filter.js)
 *)
 
-#r "./node_modules/fable-core/Fable.Core.dll"
-#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "../../node_modules/fable-core/Fable.Core.dll"
+#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core
@@ -15,6 +15,8 @@ open Fable.Core.JsInterop
 open Fable.Import.PIXI
 open Fable.Import.Browser
 open Fable.Import.JS
+
+importAll "core-js"
 
 let renderer =
   Globals.autoDetectRenderer(800., 600.)

--- a/samples/pixi/blur-filter/blur-filter.fsx
+++ b/samples/pixi/blur-filter/blur-filter.fsx
@@ -2,12 +2,12 @@
  - title: Blur Filter sample
  - tagline: Basic sample implemented with fable-pixi
  - app-style: width:800px; margin:20px auto 50px auto;
- - require-paths: `'PIXI':'https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min'`
+ - external-script: `"https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min.js"`
  - intro: This is a port from [blur filter sample](http://pixijs.github.io/examples/#/filters/blur-filter.js)
 *)
 
-#r "../../node_modules/fable-core/Fable.Core.dll"
-#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "./node_modules/fable-core/Fable.Core.dll"
+#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core

--- a/samples/pixi/blur-filter/fableconfig.json
+++ b/samples/pixi/blur-filter/fableconfig.json
@@ -1,6 +1,13 @@
 {
-    "module": "amd",
-    "sourceMaps": true,
     "projFile": "./blur-filter.fsx",
-    "outDir": "public"
+    "sourceMaps": true,
+    "babelPlugins": ["transform-runtime"],
+    "rollup": {
+        "dest": "public/bundle.js",
+        // PIXI will be loaded directly from a script tag
+        "external": ["PIXI"],
+        "globals": {
+            "PIXI": "PIXI"
+        }
+    }
 }

--- a/samples/pixi/blur-filter/index.html
+++ b/samples/pixi/blur-filter/index.html
@@ -14,24 +14,11 @@
   </head>
   <body>
 
+    <script src="./node_modules/pixi.js/bin/pixi.min.js"></script>
     <!-- [body] -->
     <div id="game"></div>
+    <script src="./public/bundle.js"></script>
     <!-- [/body] -->
-    <script src="../../node_modules/core-js/client/core.min.js"></script>
-    <script src="../../node_modules/requirejs/require.js"></script>
-
-    <script>
-      requirejs.config({
-        // Set the baseUrl to the path of the compiled JS code
-        baseUrl: 'public',
-        paths: {
-          // Explicit path to core lib (relative to baseUrl, omit .js)
-          'fable-core': '../../../node_modules/fable-core/fable-core.min',
-          'PIXI': '../../../node_modules/pixi.js/bin/pixi.min'
-        }
-      });
-      // Load the entry file of the app (use array, omit .js)
-      requirejs(["blur-filter"]);
-    </script>
+    
   </body>
 </html>

--- a/samples/pixi/blur-filter/package.json
+++ b/samples/pixi/blur-filter/package.json
@@ -5,17 +5,9 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-    "build": "node ./node_modules/fable-compiler",
+    "build": "node ../../node_modules/fable-compiler",
     "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT",
-    "dependencies": {
-    "core-js": "^2.4.1",
-    "fable-compiler": "^0.7.19",
-    "fable-core": "^0.7.15",
-    "fable-import-pixi": "0.0.10",
-    "pixi.js": "^3.0.11",
-    "babel-plugin-transform-runtime": "^6.15.0"
-  }
+  "license": "MIT"
 }

--- a/samples/pixi/blur-filter/package.json
+++ b/samples/pixi/blur-filter/package.json
@@ -5,9 +5,17 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-      "build": "node ../../node_modules/fable-compiler",
-      "start": "node ../../server"
+    "build": "node ./node_modules/fable-compiler",
+    "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT"
+  "license": "MIT",
+    "dependencies": {
+    "core-js": "^2.4.1",
+    "fable-compiler": "^0.7.19",
+    "fable-core": "^0.7.15",
+    "fable-import-pixi": "0.0.10",
+    "pixi.js": "^3.0.11",
+    "babel-plugin-transform-runtime": "^6.15.0"
+  }
 }

--- a/samples/pixi/dragging/dragging.fsx
+++ b/samples/pixi/dragging/dragging.fsx
@@ -2,12 +2,12 @@
  - title: Dragging sample
  - tagline: Basic sample implemented with fable-pixi
  - app-style: width:800px; margin:20px auto 50px auto;
- - require-paths: `'PIXI':'https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min'`
+ - external-script: `"https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min.js"`
  - intro: This is a port from [dragging sample](http://pixijs.github.io/examples/#/demos/dragging.js)
 *)
 
-#r "../../node_modules/fable-core/Fable.Core.dll"
-#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "./node_modules/fable-core/Fable.Core.dll"
+#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core

--- a/samples/pixi/dragging/dragging.fsx
+++ b/samples/pixi/dragging/dragging.fsx
@@ -6,8 +6,8 @@
  - intro: This is a port from [dragging sample](http://pixijs.github.io/examples/#/demos/dragging.js)
 *)
 
-#r "./node_modules/fable-core/Fable.Core.dll"
-#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "../../node_modules/fable-core/Fable.Core.dll"
+#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core
@@ -15,6 +15,8 @@ open Fable.Core.JsInterop
 open Fable.Import.PIXI
 open Fable.Import.Browser
 open Fable.Import.JS
+
+importAll "core-js"
 
 let renderer =
   Globals.autoDetectRenderer( 800., 600. )

--- a/samples/pixi/dragging/fableconfig.json
+++ b/samples/pixi/dragging/fableconfig.json
@@ -1,6 +1,13 @@
 {
-    "module": "amd",
+"projFile": "./dragging.fsx",
     "sourceMaps": true,
-    "projFile": "./dragging.fsx",
-    "outDir": "public"
+    "babelPlugins": ["transform-runtime"],
+    "rollup": {
+        "dest": "public/bundle.js",
+        // PIXI will be loaded directly from a script tag
+        "external": ["PIXI"],
+        "globals": {
+            "PIXI": "PIXI"
+        }
+    }
 }

--- a/samples/pixi/dragging/index.html
+++ b/samples/pixi/dragging/index.html
@@ -14,24 +14,11 @@
   </head>
   <body>
 
+    <script src="./node_modules/pixi.js/bin/pixi.min.js"></script>
     <!-- [body] -->
     <div id="game"></div>
+    <script src="./public/bundle.js"></script>
     <!-- [/body] -->
-    <script src="../../node_modules/core-js/client/core.min.js"></script>
-    <script src="../../node_modules/requirejs/require.js"></script>
-
-    <script>
-      requirejs.config({
-        // Set the baseUrl to the path of the compiled JS code
-        baseUrl: 'public',
-        paths: {
-          // Explicit path to core lib (relative to baseUrl, omit .js)
-          'fable-core': '../../../node_modules/fable-core/fable-core.min',
-          'PIXI': '../../../node_modules/pixi.js/bin/pixi.min'
-        }
-      });
-      // Load the entry file of the app (use array, omit .js)
-      requirejs(["dragging"]);
-    </script>
+    
   </body>
 </html>

--- a/samples/pixi/dragging/package.json
+++ b/samples/pixi/dragging/package.json
@@ -5,17 +5,9 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-    "build": "node ./node_modules/fable-compiler",
+    "build": "node ../../node_modules/fable-compiler",
     "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT",
-  "dependencies": {
-    "core-js": "^2.4.1",
-    "fable-compiler": "^0.7.19",
-    "fable-core": "^0.7.15",
-    "fable-import-pixi": "0.0.10",
-    "pixi.js": "^3.0.11",
-    "babel-plugin-transform-runtime": "^6.15.0"
-  }
+  "license": "MIT"
 }

--- a/samples/pixi/dragging/package.json
+++ b/samples/pixi/dragging/package.json
@@ -5,9 +5,17 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-      "build": "node ../../node_modules/fable-compiler",
-      "start": "node ../../server"
+    "build": "node ./node_modules/fable-compiler",
+    "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "core-js": "^2.4.1",
+    "fable-compiler": "^0.7.19",
+    "fable-core": "^0.7.15",
+    "fable-import-pixi": "0.0.10",
+    "pixi.js": "^3.0.11",
+    "babel-plugin-transform-runtime": "^6.15.0"
+  }
 }

--- a/samples/pixi/graphics/fableconfig.json
+++ b/samples/pixi/graphics/fableconfig.json
@@ -1,6 +1,13 @@
 {
-    "module": "amd",
-    "sourceMaps": true,
     "projFile": "./graphics.fsx",
-    "outDir": "public"
+    "sourceMaps": true,
+    "babelPlugins": ["transform-runtime"],
+    "rollup": {
+        "dest": "public/bundle.js",
+        // PIXI will be loaded directly from a script tag
+        "external": ["PIXI"],
+        "globals": {
+            "PIXI": "PIXI"
+        }
+    }
 }

--- a/samples/pixi/graphics/graphics.fsx
+++ b/samples/pixi/graphics/graphics.fsx
@@ -6,8 +6,8 @@
  - intro: This is a port from [graphics sample](http://pixijs.github.io/examples/#/demos/graphics-demo.js)
 *)
 
-#r "./node_modules/fable-core/Fable.Core.dll"
-#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "../../node_modules/fable-core/Fable.Core.dll"
+#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core
@@ -15,6 +15,8 @@ open Fable.Core.JsInterop
 open Fable.Import.PIXI
 open Fable.Import.Browser
 open Fable.Import.JS
+
+importAll "core-js"
 
 let options = [
   Antialias true

--- a/samples/pixi/graphics/graphics.fsx
+++ b/samples/pixi/graphics/graphics.fsx
@@ -2,12 +2,12 @@
  - title: Graphics sample
  - tagline: Basic sample implemented with fable-pixi
  - app-style: width:800px; margin:20px auto 50px auto;
- - require-paths: `'PIXI':'https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min'`
+ - external-script: `"https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min.js"`
  - intro: This is a port from [graphics sample](http://pixijs.github.io/examples/#/demos/graphics-demo.js)
 *)
 
-#r "../../node_modules/fable-core/Fable.Core.dll"
-#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "./node_modules/fable-core/Fable.Core.dll"
+#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core

--- a/samples/pixi/graphics/index.html
+++ b/samples/pixi/graphics/index.html
@@ -14,24 +14,11 @@
   </head>
   <body>
 
+    <script src="./node_modules/pixi.js/bin/pixi.min.js"></script>
     <!-- [body] -->
     <div id="game"></div>
+    <script src="./public/bundle.js"></script>
     <!-- [/body] -->
-    <script src="../../node_modules/core-js/client/core.min.js"></script>
-    <script src="../../node_modules/requirejs/require.js"></script>
-
-    <script>
-      requirejs.config({
-        // Set the baseUrl to the path of the compiled JS code
-        baseUrl: 'public',
-        paths: {
-          // Explicit path to core lib (relative to baseUrl, omit .js)
-          'fable-core': '../../../node_modules/fable-core/fable-core.min',
-          'PIXI': '../../../node_modules/pixi.js/bin/pixi.min'
-        }
-      });
-      // Load the entry file of the app (use array, omit .js)
-      requirejs(["graphics"]);
-    </script>
+    
   </body>
 </html>

--- a/samples/pixi/graphics/package.json
+++ b/samples/pixi/graphics/package.json
@@ -5,17 +5,9 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-    "build": "node ./node_modules/fable-compiler",
+    "build": "node ../../node_modules/fable-compiler",
     "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT",
-  "dependencies": {
-    "core-js": "^2.4.1",
-    "fable-compiler": "^0.7.19",
-    "fable-core": "^0.7.15",
-    "fable-import-pixi": "0.0.10",
-    "pixi.js": "^3.0.11",
-    "babel-plugin-transform-runtime": "^6.15.0"
-  }
+  "license": "MIT"
 }

--- a/samples/pixi/graphics/package.json
+++ b/samples/pixi/graphics/package.json
@@ -5,9 +5,17 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-      "build": "node ../../node_modules/fable-compiler",
-      "start": "node ../../server"
+    "build": "node ./node_modules/fable-compiler",
+    "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "core-js": "^2.4.1",
+    "fable-compiler": "^0.7.19",
+    "fable-core": "^0.7.15",
+    "fable-import-pixi": "0.0.10",
+    "pixi.js": "^3.0.11",
+    "babel-plugin-transform-runtime": "^6.15.0"
+  }
 }

--- a/samples/pixi/masking/fableconfig.json
+++ b/samples/pixi/masking/fableconfig.json
@@ -1,6 +1,13 @@
 {
-    "module": "amd",
-    "sourceMaps": true,
     "projFile": "./masking.fsx",
-    "outDir": "public"
+    "sourceMaps": true,
+    "babelPlugins": ["transform-runtime"],
+    "rollup": {
+        "dest": "public/bundle.js",
+        // PIXI will be loaded directly from a script tag
+        "external": ["PIXI"],
+        "globals": {
+            "PIXI": "PIXI"
+        }
+    }
 }

--- a/samples/pixi/masking/index.html
+++ b/samples/pixi/masking/index.html
@@ -14,24 +14,11 @@
   </head>
   <body>
 
+    <script src="./node_modules/pixi.js/bin/pixi.min.js"></script>
     <!-- [body] -->
     <div id="game"></div>
+    <script src="./public/bundle.js"></script>
     <!-- [/body] -->
-    <script src="../../node_modules/core-js/client/core.min.js"></script>
-    <script src="../../node_modules/requirejs/require.js"></script>
 
-    <script>
-      requirejs.config({
-        // Set the baseUrl to the path of the compiled JS code
-        baseUrl: 'public',
-        paths: {
-          // Explicit path to core lib (relative to baseUrl, omit .js)
-          'fable-core': '../../../node_modules/fable-core/fable-core.min',
-          'PIXI': '../../../node_modules/pixi.js/bin/pixi.min'
-        }
-      });
-      // Load the entry file of the app (use array, omit .js)
-      requirejs(["masking"]);
-    </script>
   </body>
 </html>

--- a/samples/pixi/masking/masking.fsx
+++ b/samples/pixi/masking/masking.fsx
@@ -6,8 +6,8 @@
  - intro: This is a port from [Masking sample](http://pixijs.github.io/examples/#/demos/masking.js)
 *)
 
-#r "./node_modules/fable-core/Fable.Core.dll"
-#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "../../node_modules/fable-core/Fable.Core.dll"
+#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core
@@ -16,6 +16,8 @@ open Fable.Import
 open Fable.Import.PIXI
 open Fable.Import.Browser
 open Fable.Import.JS
+
+importAll "core-js"
 
 let renderer = WebGLRenderer( 800., 600. )
 
@@ -127,7 +129,7 @@ let animate =
 
     window.requestAnimationFrame(FrameRequestCallback animate) |> ignore
     renderer.render(stage)
-  
+
   animate // Return `animate` function with `count` trapped in a closure
 
 // start animating

--- a/samples/pixi/masking/masking.fsx
+++ b/samples/pixi/masking/masking.fsx
@@ -2,12 +2,12 @@
  - title: Masking sample
  - tagline: Basic sample implemented with fable-pixi
  - app-style: width:800px; margin:20px auto 50px auto;
- - require-paths: `'PIXI':'https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min'`
+ - external-script: `"https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min.js"`
  - intro: This is a port from [Masking sample](http://pixijs.github.io/examples/#/demos/masking.js)
 *)
 
-#r "../../node_modules/fable-core/Fable.Core.dll"
-#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "./node_modules/fable-core/Fable.Core.dll"
+#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core

--- a/samples/pixi/masking/package.json
+++ b/samples/pixi/masking/package.json
@@ -5,17 +5,9 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-    "build": "node ./node_modules/fable-compiler",
+    "build": "node ../../node_modules/fable-compiler",
     "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT",
-  "dependencies": {
-    "core-js": "^2.4.1",
-    "fable-compiler": "^0.7.19",
-    "fable-core": "^0.7.15",
-    "fable-import-pixi": "0.0.10",
-    "pixi.js": "^3.0.11",
-    "babel-plugin-transform-runtime": "^6.15.0"
-  }
+  "license": "MIT"
 }

--- a/samples/pixi/masking/package.json
+++ b/samples/pixi/masking/package.json
@@ -5,9 +5,17 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-      "build": "node ../../node_modules/fable-compiler",
-      "start": "node ../../server"
+    "build": "node ./node_modules/fable-compiler",
+    "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "core-js": "^2.4.1",
+    "fable-compiler": "^0.7.19",
+    "fable-core": "^0.7.15",
+    "fable-import-pixi": "0.0.10",
+    "pixi.js": "^3.0.11",
+    "babel-plugin-transform-runtime": "^6.15.0"
+  }
 }

--- a/samples/pixi/movieclip/fableconfig.json
+++ b/samples/pixi/movieclip/fableconfig.json
@@ -1,6 +1,13 @@
 {
-    "module": "amd",
-    "sourceMaps": true,
     "projFile": "./movieclip.fsx",
-    "outDir": "public"
+    "sourceMaps": true,
+    "babelPlugins": ["transform-runtime"],
+    "rollup": {
+        "dest": "public/bundle.js",
+        // PIXI will be loaded directly from a script tag
+        "external": ["PIXI"],
+        "globals": {
+            "PIXI": "PIXI"
+        }
+    }
 }

--- a/samples/pixi/movieclip/index.html
+++ b/samples/pixi/movieclip/index.html
@@ -14,24 +14,11 @@
   </head>
   <body>
 
+    <script src="./node_modules/pixi.js/bin/pixi.min.js"></script>
     <!-- [body] -->
     <div id="game"></div>
+    <script src="./public/bundle.js"></script>
     <!-- [/body] -->
-    <script src="../../node_modules/core-js/client/core.min.js"></script>
-    <script src="../../node_modules/requirejs/require.js"></script>
 
-    <script>
-      requirejs.config({
-        // Set the baseUrl to the path of the compiled JS code
-        baseUrl: 'public',
-        paths: {
-          // Explicit path to core lib (relative to baseUrl, omit .js)
-          'fable-core': '../../../node_modules/fable-core/fable-core.min',
-          'PIXI': '../../../node_modules/pixi.js/bin/pixi.min'
-        }
-      });
-      // Load the entry file of the app (use array, omit .js)
-      requirejs(["movieclip"]);
-    </script>
   </body>
 </html>

--- a/samples/pixi/movieclip/movieclip.fsx
+++ b/samples/pixi/movieclip/movieclip.fsx
@@ -2,12 +2,12 @@
  - title: MovieClip sample
  - tagline: Basic sample implemented with fable-pixi
  - app-style: width:800px; margin:20px auto 50px auto;
- - require-paths: `'PIXI':'https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min'`
+ - external-script: `"https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min.js"`
  - intro: This is a port from [MovieClip sample](http://pixijs.github.io/examples/#/demos/movieclip-demo.js)
 *)
 
-#r "../../node_modules/fable-core/Fable.Core.dll"
-#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "./node_modules/fable-core/Fable.Core.dll"
+#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core

--- a/samples/pixi/movieclip/movieclip.fsx
+++ b/samples/pixi/movieclip/movieclip.fsx
@@ -6,8 +6,8 @@
  - intro: This is a port from [MovieClip sample](http://pixijs.github.io/examples/#/demos/movieclip-demo.js)
 *)
 
-#r "./node_modules/fable-core/Fable.Core.dll"
-#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "../../node_modules/fable-core/Fable.Core.dll"
+#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core
@@ -15,6 +15,8 @@ open Fable.Core.JsInterop
 open Fable.Import.PIXI
 open Fable.Import.Browser
 open Fable.Import.JS
+
+importAll "core-js"
 
 let renderer = WebGLRenderer( 800., 600. )
 

--- a/samples/pixi/movieclip/package.json
+++ b/samples/pixi/movieclip/package.json
@@ -5,17 +5,9 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-    "build": "node ./node_modules/fable-compiler",
+    "build": "node ../../node_modules/fable-compiler",
     "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT",
-  "dependencies": {
-    "core-js": "^2.4.1",
-    "fable-compiler": "^0.7.19",
-    "fable-core": "^0.7.15",
-    "fable-import-pixi": "0.0.10",
-    "pixi.js": "^3.0.11",
-    "babel-plugin-transform-runtime": "^6.15.0"
-  }
+  "license": "MIT"
 }

--- a/samples/pixi/movieclip/package.json
+++ b/samples/pixi/movieclip/package.json
@@ -5,9 +5,17 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-      "build": "node ../../node_modules/fable-compiler",
-      "start": "node ../../server"
+    "build": "node ./node_modules/fable-compiler",
+    "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "core-js": "^2.4.1",
+    "fable-compiler": "^0.7.19",
+    "fable-core": "^0.7.15",
+    "fable-import-pixi": "0.0.10",
+    "pixi.js": "^3.0.11",
+    "babel-plugin-transform-runtime": "^6.15.0"
+  }
 }

--- a/samples/pixi/particle-container/fableconfig.json
+++ b/samples/pixi/particle-container/fableconfig.json
@@ -1,6 +1,13 @@
 {
-    "module": "amd",
-    "sourceMaps": true,
     "projFile": "./particle-container.fsx",
-    "outDir": "public"
+    "sourceMaps": true,
+    "babelPlugins": ["transform-runtime"],
+    "rollup": {
+        "dest": "public/bundle.js",
+        // PIXI will be loaded directly from a script tag
+        "external": ["PIXI"],
+        "globals": {
+            "PIXI": "PIXI"
+        }
+    }
 }

--- a/samples/pixi/particle-container/index.html
+++ b/samples/pixi/particle-container/index.html
@@ -14,24 +14,11 @@
   </head>
   <body>
 
+    <script src="./node_modules/pixi.js/bin/pixi.min.js"></script>
     <!-- [body] -->
     <div id="game"></div>
+    <script src="./public/bundle.js"></script>
     <!-- [/body] -->
-    <script src="../../node_modules/core-js/client/core.min.js"></script>
-    <script src="../../node_modules/requirejs/require.js"></script>
 
-    <script>
-      requirejs.config({
-        // Set the baseUrl to the path of the compiled JS code
-        baseUrl: 'public',
-        paths: {
-          // Explicit path to core lib (relative to baseUrl, omit .js)
-          'fable-core': '../../../node_modules/fable-core/fable-core.min',
-          'PIXI': '../../../node_modules/pixi.js/bin/pixi.min'
-        }
-      });
-      // Load the entry file of the app (use array, omit .js)
-      requirejs(["particle-container"]);
-    </script>
   </body>
 </html>

--- a/samples/pixi/particle-container/package.json
+++ b/samples/pixi/particle-container/package.json
@@ -5,17 +5,9 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-    "build": "node ./node_modules/fable-compiler",
+    "build": "node ../../node_modules/fable-compiler",
     "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT",
-  "dependencies": {
-    "core-js": "^2.4.1",
-    "fable-compiler": "^0.7.19",
-    "fable-core": "^0.7.15",
-    "fable-import-pixi": "0.0.10",
-    "pixi.js": "^3.0.11",
-    "babel-plugin-transform-runtime": "^6.15.0"
-  }
+  "license": "MIT"
 }

--- a/samples/pixi/particle-container/package.json
+++ b/samples/pixi/particle-container/package.json
@@ -5,9 +5,17 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-      "build": "node ../../node_modules/fable-compiler",
-      "start": "node ../../server"
+    "build": "node ./node_modules/fable-compiler",
+    "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "core-js": "^2.4.1",
+    "fable-compiler": "^0.7.19",
+    "fable-core": "^0.7.15",
+    "fable-import-pixi": "0.0.10",
+    "pixi.js": "^3.0.11",
+    "babel-plugin-transform-runtime": "^6.15.0"
+  }
 }

--- a/samples/pixi/particle-container/particle-container.fsx
+++ b/samples/pixi/particle-container/particle-container.fsx
@@ -6,8 +6,8 @@
  - intro: This is a port from [Particle Container sample](http://pixijs.github.io/examples/#/demos/batch-v3.js)
 *)
 
-#r "./node_modules/fable-core/Fable.Core.dll"
-#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "../../node_modules/fable-core/Fable.Core.dll"
+#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core
@@ -15,6 +15,8 @@ open Fable.Core.JsInterop
 open Fable.Import.PIXI
 open Fable.Import.Browser
 open Fable.Import.JS
+
+importAll "core-js"
 
 let isWebGL, renderer =
   match Globals.autoDetectRenderer(800., 600.) with
@@ -100,18 +102,18 @@ let animate =
       let dude = maggots.[i]
       dude.scale.y <-
         0.95 + Math.sin(tick + unbox dude?offset) * 0.05
-      
+
       dude?direction <-
         (unbox dude?direction) + (unbox dude?turningSpeed) * 0.01
-      
+
       dude.position.x <-
         dude.position.x + Math.sin(unbox dude?direction)
         * (unbox dude?speed) * dude.scale.y
-      
+
       dude.position.y <-
         dude.position.y + Math.cos(unbox dude?direction)
         * (unbox dude?speed) * dude.scale.y
-      
+
       dude.rotation <-
         -(unbox dude?direction) - Math.PI
 
@@ -125,12 +127,12 @@ let animate =
       then dude.position.y <- dude.position.y + dudeBounds.height
       elif (dude.position.y > dudeBounds.y + dudeBounds.height)
       then dude.position.y <- dude.position.y - dudeBounds.height
-    
+
     // increment the ticker
     tick <- tick + 0.1
     window.requestAnimationFrame(FrameRequestCallback animate) |> ignore
     renderer.render(stage)
-  
+
   animate // Return `animate` function with `tick` trapped in a closure
 
 // start animating

--- a/samples/pixi/particle-container/particle-container.fsx
+++ b/samples/pixi/particle-container/particle-container.fsx
@@ -2,12 +2,12 @@
  - title: Particle Container sample
  - tagline: Basic sample implemented with fable-pixi
  - app-style: width:800px; margin:20px auto 50px auto;
- - require-paths: `'PIXI':'https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min'`
+ - external-script: `"https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min.js"`
  - intro: This is a port from [Particle Container sample](http://pixijs.github.io/examples/#/demos/batch-v3.js)
 *)
 
-#r "../../node_modules/fable-core/Fable.Core.dll"
-#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "./node_modules/fable-core/Fable.Core.dll"
+#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core

--- a/samples/pixi/render-texture/fableconfig.json
+++ b/samples/pixi/render-texture/fableconfig.json
@@ -1,6 +1,13 @@
 {
-    "module": "amd",
-    "sourceMaps": true,
     "projFile": "./render-texture.fsx",
-    "outDir": "public"
+    "sourceMaps": true,
+    "babelPlugins": ["transform-runtime"],
+    "rollup": {
+        "dest": "public/bundle.js",
+        // PIXI will be loaded directly from a script tag
+        "external": ["PIXI"],
+        "globals": {
+            "PIXI": "PIXI"
+        }
+    }
 }

--- a/samples/pixi/render-texture/index.html
+++ b/samples/pixi/render-texture/index.html
@@ -14,24 +14,11 @@
   </head>
   <body>
 
+    <script src="./node_modules/pixi.js/bin/pixi.min.js"></script>
     <!-- [body] -->
     <div id="game"></div>
+    <script src="./public/bundle.js"></script>
     <!-- [/body] -->
-    <script src="../../node_modules/core-js/client/core.min.js"></script>
-    <script src="../../node_modules/requirejs/require.js"></script>
 
-    <script>
-      requirejs.config({
-        // Set the baseUrl to the path of the compiled JS code
-        baseUrl: 'public',
-        paths: {
-          // Explicit path to core lib (relative to baseUrl, omit .js)
-          'fable-core': '../../../node_modules/fable-core/fable-core.min',
-          'PIXI': '../../../node_modules/pixi.js/bin/pixi.min'
-        }
-      });
-      // Load the entry file of the app (use array, omit .js)
-      requirejs(["render-texture"]);
-    </script>
   </body>
 </html>

--- a/samples/pixi/render-texture/package.json
+++ b/samples/pixi/render-texture/package.json
@@ -5,17 +5,9 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-    "build": "node ./node_modules/fable-compiler",
+    "build": "node ../../node_modules/fable-compiler",
     "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT",
-  "dependencies": {
-    "core-js": "^2.4.1",
-    "fable-compiler": "^0.7.19",
-    "fable-core": "^0.7.15",
-    "fable-import-pixi": "0.0.10",
-    "pixi.js": "^3.0.11",
-    "babel-plugin-transform-runtime": "^6.15.0"
-  }
+  "license": "MIT"
 }

--- a/samples/pixi/render-texture/package.json
+++ b/samples/pixi/render-texture/package.json
@@ -5,9 +5,17 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-      "build": "node ../../node_modules/fable-compiler",
-      "start": "node ../../server"
+    "build": "node ./node_modules/fable-compiler",
+    "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "core-js": "^2.4.1",
+    "fable-compiler": "^0.7.19",
+    "fable-core": "^0.7.15",
+    "fable-import-pixi": "0.0.10",
+    "pixi.js": "^3.0.11",
+    "babel-plugin-transform-runtime": "^6.15.0"
+  }
 }

--- a/samples/pixi/render-texture/render-texture.fsx
+++ b/samples/pixi/render-texture/render-texture.fsx
@@ -2,12 +2,12 @@
  - title: Render Texture sample
  - tagline: Basic sample implemented with fable-pixi
  - app-style: width:800px; margin:20px auto 50px auto;
- - require-paths: `'PIXI':'https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min'`
+ - external-script: `"https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min.js"`
  - intro: This is a port from [Render texture sample](http://pixijs.github.io/examples/#/demos/render-texture-demo.js)
 *)
 
-#r "../../node_modules/fable-core/Fable.Core.dll"
-#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "./node_modules/fable-core/Fable.Core.dll"
+#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core

--- a/samples/pixi/render-texture/render-texture.fsx
+++ b/samples/pixi/render-texture/render-texture.fsx
@@ -6,8 +6,8 @@
  - intro: This is a port from [Render texture sample](http://pixijs.github.io/examples/#/demos/render-texture-demo.js)
 *)
 
-#r "./node_modules/fable-core/Fable.Core.dll"
-#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "../../node_modules/fable-core/Fable.Core.dll"
+#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core
@@ -15,6 +15,8 @@ open Fable.Core.JsInterop
 open Fable.Import.PIXI
 open Fable.Import.Browser
 open Fable.Import.JS
+
+importAll "core-js"
 
 let renderer = WebGLRenderer( 800., 600. )
 
@@ -103,7 +105,7 @@ let animate =
 
     // render the container
     renderer.render(stage)
-  
+
   animate // Return `animate` function with `count` trapped in a closure
 
 animate 0.

--- a/samples/pixi/text/fableconfig.json
+++ b/samples/pixi/text/fableconfig.json
@@ -1,6 +1,13 @@
 {
-    "module": "amd",
-    "sourceMaps": true,
     "projFile": "./text.fsx",
-    "outDir": "public"
+    "sourceMaps": true,
+    "babelPlugins": ["transform-runtime"],
+    "rollup": {
+        "dest": "public/bundle.js",
+        // PIXI will be loaded directly from a script tag
+        "external": ["PIXI"],
+        "globals": {
+            "PIXI": "PIXI"
+        }
+    }
 }

--- a/samples/pixi/text/index.html
+++ b/samples/pixi/text/index.html
@@ -14,24 +14,11 @@
   </head>
   <body>
 
+    <script src="./node_modules/pixi.js/bin/pixi.min.js"></script>
     <!-- [body] -->
     <div id="game"></div>
+    <script src="./public/bundle.js"></script>
     <!-- [/body] -->
-    <script src="../../node_modules/core-js/client/core.min.js"></script>
-    <script src="../../node_modules/requirejs/require.js"></script>
 
-    <script>
-      requirejs.config({
-        // Set the baseUrl to the path of the compiled JS code
-        baseUrl: 'public',
-        paths: {
-          // Explicit path to core lib (relative to baseUrl, omit .js)
-          'fable-core': '../../../node_modules/fable-core/fable-core.min',
-          'PIXI': '../../../node_modules/pixi.js/bin/pixi.min'
-        }
-      });
-      // Load the entry file of the app (use array, omit .js)
-      requirejs(["text"]);
-    </script>
   </body>
 </html>

--- a/samples/pixi/text/package.json
+++ b/samples/pixi/text/package.json
@@ -5,17 +5,9 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-    "build": "node ./node_modules/fable-compiler",
+    "build": "node ../../node_modules/fable-compiler",
     "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT",
-  "dependencies": {
-    "core-js": "^2.4.1",
-    "fable-compiler": "^0.7.19",
-    "fable-core": "^0.7.15",
-    "fable-import-pixi": "0.0.10",
-    "pixi.js": "^3.0.11",
-    "babel-plugin-transform-runtime": "^6.15.0"
-  }
+  "license": "MIT"
 }

--- a/samples/pixi/text/package.json
+++ b/samples/pixi/text/package.json
@@ -5,9 +5,17 @@
   "description": "F# port of pixi.js official samples",
   "main": "index.js",
   "scripts": {
-      "build": "node ../../node_modules/fable-compiler",
-      "start": "node ../../server"
+    "build": "node ./node_modules/fable-compiler",
+    "start": "node ../../server"
   },
   "author": "François Nicaise",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "core-js": "^2.4.1",
+    "fable-compiler": "^0.7.19",
+    "fable-core": "^0.7.15",
+    "fable-import-pixi": "0.0.10",
+    "pixi.js": "^3.0.11",
+    "babel-plugin-transform-runtime": "^6.15.0"
+  }
 }

--- a/samples/pixi/text/text.fsx
+++ b/samples/pixi/text/text.fsx
@@ -2,12 +2,12 @@
  - title: Text sample
  - tagline: Basic sample implemented with fable-pixi
  - app-style: width:800px; margin:20px auto 50px auto;
- - require-paths: `'PIXI':'https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min'`
+ - external-script: `"https://cdnjs.cloudflare.com/ajax/libs/pixi.js/3.0.11/pixi.min.js"`
  - intro: This is a port from [text sample](http://pixijs.github.io/examples/#/demos/text-demo.js)
 *)
 
-#r "../../node_modules/fable-core/Fable.Core.dll"
-#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "./node_modules/fable-core/Fable.Core.dll"
+#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core

--- a/samples/pixi/text/text.fsx
+++ b/samples/pixi/text/text.fsx
@@ -6,8 +6,8 @@
  - intro: This is a port from [text sample](http://pixijs.github.io/examples/#/demos/text-demo.js)
 *)
 
-#r "./node_modules/fable-core/Fable.Core.dll"
-#load "./node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
+#r "../../node_modules/fable-core/Fable.Core.dll"
+#load "../../node_modules/fable-import-pixi/Fable.Import.Pixi.fs"
 
 open System
 open Fable.Core
@@ -16,6 +16,8 @@ open Fable.Import
 open Fable.Import.PIXI
 open Fable.Import.Browser
 open Fable.Import.JS
+
+importAll "core-js"
 
 let renderer =
   Globals.autoDetectRenderer( 620., 400. )


### PR DESCRIPTION
@alfonsogarciacaro Can you please give me your opinion on this PR.

I switched all the samples of pixi to make them use **Fable 0.7 + Rollup**.
So now, we got each samples with their own deps which means now they are trully self-hosted in their directory.

However this is a rollback from a previous version because before you added a "shared" dependencies.

This new way of bundling the sample take some times:
- First GenerateDocs (no node_modules installed) took 5min on my PC
- Others GenerateDocs took 3 min on my PC

For me it's not really a problem because we don't build samples every 5 minutes. After, if you have a better idea, we could give it a try.

Personnally, I prefer having each samples self-hosted because users can simply extract them and directly play with it.

This PR should Fix #6